### PR TITLE
Add support for more character encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ encodings at the following levels:
 |     Name     | Standard | ICU4J | BOM | Laptop |
 |:------------:|:--------:|:-----:|:---:|:------:|
 | Big5         |          |   ✔   |     |    ✔   |
-| BOCU-1       |          |       |  ✔  |        |
 | EUC-JP       |          |   ✔   |     |    ✔   |
 | EUC-KR       |          |   ✔   |     |    ✔   |
 | GB18030      |          |   ✔   |  ✔  |    ✔   |
@@ -118,7 +117,6 @@ encodings at the following levels:
 | ISO-8859-8-I |          |   ✔   |     |        |
 | ISO-8859-9   |          |   ✔   |     |    ✔   |
 | KOI8-R       |          |   ✔   |     |    ✔   |
-| SCSU         |          |       |  ✔  |        |
 | Shift_JIS    |          |   ✔   |     |    ✔   |
 | US-ASCII     |     ✔    |   ✔*  |     |    ✔   |
 | UTF-1        |          |       |  ✔  |        |
@@ -126,7 +124,6 @@ encodings at the following levels:
 | UTF-16LE     |     ✔    |   ✔   |  ✔  |    ✔   |
 | UTF-32BE     |          |   ✔   |  ✔  |    ✔   |
 | UTF-32LE     |          |   ✔   |  ✔  |    ✔   |
-| UTF-7        |          |       |  ✔  |        |
 | UTF-8        |     ✔    |   ✔   |  ✔  |    ✔   |
 | UTF-EBCDIC   |          |       |  ✔  |        |
 | windows-1250 |          |   ✔   |     |    ✔   |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ The library can be found in Maven Central with the following coordinates:
 
 It is compatible with Java versions 8 and later.
 
+The `$major.$minor.$patch` version of the library is determined by the underlying
+icu4j version and the local release version. The `$major` and `$minor` are taken
+from the icu4j version, and `$patch` is the release number of this library for
+the icu4j version, starting with 0.
+
 ## Getting Started
 
 To decode an `InputStream` to a `Reader` by detecting its character set:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ detection:
 Byte arrays can be converted directly to Strings as well:
 
     String chars=Chardet.decode(bytes, declaredEncoding, StandardCharsets.UTF_8);
+    
+Users only interested in detection can detect the charset directly, or by name
+in case the detected charset is not supported by the JVM:
+
+    // Throws an UnsupportedCharsetException if the charset is not supported by JVM
+    Optional<Charset> maybeCharset = Chardet.detect(bytes, declaredEncoding);
+    
+    // Never throws
+    Optional<String> maybeCharsetName = Chardet.detectName(bytes, declaredEncoding);
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,61 @@ Byte arrays can be converted directly to Strings as well:
 Users can simply detect a character set, too:
 
     Optional<Charset> maybeCharset=Chardet.detectCharset(bytes, declaredEncoding);
+    
+## Supported Character Encodings
+
+The chardet4j library and Java in general supports the following character
+encodings at the following levels:
+
+|     Name     | Standard | ICU4J | BOM | Laptop |
+|:------------:|:--------:|:-----:|:---:|:------:|
+| Big5         |          |   ✔   |     |    ✔   |
+| BOCU-1       |          |       |  ✔  |        |
+| EUC-JP       |          |   ✔   |     |    ✔   |
+| EUC-KR       |          |   ✔   |     |    ✔   |
+| GB18030      |          |   ✔   |  ✔  |    ✔   |
+| ISO-2022-CN  |          |   ✔   |     |    ✔   |
+| ISO-2022-JP  |          |   ✔   |     |    ✔   |
+| ISO-2022-KR  |          |   ✔   |     |    ✔   |
+| ISO-8859-1   |          |   ✔   |     |    ✔   |
+| ISO-8859-2   |          |   ✔   |     |    ✔   |
+| ISO-8859-5   |          |   ✔   |     |    ✔   |
+| ISO-8859-6   |          |   ✔   |     |    ✔   |
+| ISO-8859-7   |          |   ✔   |     |    ✔   |
+| ISO-8859-8   |          |   ✔   |     |    ✔   |
+| ISO-8859-8-I |          |   ✔   |     |        |
+| ISO-8859-9   |          |   ✔   |     |    ✔   |
+| KOI8-R       |          |   ✔   |     |    ✔   |
+| SCSU         |          |       |  ✔  |        |
+| Shift_JIS    |          |   ✔   |     |    ✔   |
+| US-ASCII     |     ✔    |   ✔*  |     |    ✔   |
+| UTF-1        |          |       |  ✔  |        |
+| UTF-16BE     |     ✔    |   ✔   |  ✔  |    ✔   |
+| UTF-16LE     |     ✔    |   ✔   |  ✔  |    ✔   |
+| UTF-32BE     |          |   ✔   |  ✔  |    ✔   |
+| UTF-32LE     |          |   ✔   |  ✔  |    ✔   |
+| UTF-7        |          |       |  ✔  |        |
+| UTF-8        |     ✔    |   ✔   |  ✔  |    ✔   |
+| UTF-EBCDIC   |          |       |  ✔  |        |
+| windows-1250 |          |   ✔   |     |    ✔   |
+| windows-1251 |          |   ✔   |     |    ✔   |
+| windows-1252 |          |   ✔   |     |    ✔   |
+| windows-1253 |          |   ✔   |     |    ✔   |
+| windows-1254 |          |   ✔   |     |    ✔   |
+| windows-1255 |          |   ✔   |     |    ✔   |
+| windows-1256 |          |   ✔   |     |    ✔   |
+|:------------:|:--------:|:-----:|:---:|:------:|
+|     Name     | Standard | ICU4J | BOM | Laptop |
+
+Notes:
+`*`: ICU4J detects US-ASCII as ISO-8859-1, a superset of US-ASCII
+
+The support levels have the following meanings:
+
+* `Standard` -- The Java Standard requires that all JVMs support this character encoding
+* `ICU4J` -- The ICU4J project has a bespoke charset recognizer for this character encoding
+* `BOM` -- The character encoding can be detected by Byte Order Mark
+* `Laptop` -- The character sets supported by `java version "1.8.0_321"` on my laptop (Obviously, this test is completely unscientific. If you have a better suggestion, please open an issue!)
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -17,83 +17,160 @@ JARs. At the time of this writing, the chardet4j JAR comes in around
 This library also implements some other important components of
 character set detection and decoding, namely byte order mark handling.
 
+## Features
+
+The library assists the user with detecting character set encodings for byte
+streams and decoding them into character streams. It offers specific
+abstractions for byte order marks (BOMs) and specific methods for identifying
+and decoding character encodings for byte arrays and input streams.
+
+The library uses the following algorithm to determine character encoding of
+binary data:
+
+1. Check for a BOM. If one is present, then trust it, and use the corresponding
+   charset to decode the data.
+2. Use a battery of bespoke character set detectors to guess which charset is
+   most likely. Users may provide a declared encoding, which provides a boost
+   to the given charset in this estimation process. If a charset is identified
+   with sufficient confidence, then use it to decode the data.
+3. The default charset is used to decode the data, if one is given.
+
+## Installation
+
+The library can be found in Maven Central with the following coordinates:
+
+    <dependency>
+        <groupId>com.sigpwned</groupId>
+        <artifactId>chardet4j</artifactId>
+        <version>75.1.0</version>
+    </dependency>
+
+It is compatible with Java versions 8 and later.
+
 ## Getting Started
 
 To decode an `InputStream` to a `Reader` by detecting its character set:
 
-    // Easy-to-use DecodedInputStreamReader implementation is AutoCloseable and makes
-    // the detected charset available.
-    try (DecodedInputStreamReader chars=
-            Chardet.decode(bytes, StandardCharsets.UTF_8)) {
-        // One of the following has happened:
-        // - The charset was detected and is supported by current JVM
-        // - The charset could not be detected and given default (UTF-8) being used
-        
-        // This is the charset being used to decode characters
-        Charset detectedCharset = chars.charset();
-        
+    try (Reader chars=Chardet.decode(bytes, StandardCharsets.UTF_8)) {
         // Process chars here
-    } catch(UnsupportedCharsetException e) {
-        // The charset was detected, but is not supported by current JVM.
     }
 
-Charset detection is important when dealing with content of unknown
-provenance, like content downloaded from the internet. In such cases,
-users often have a declared encoding, typically from a content
-type. The name of the declared encoding can be provided as a hint to
-charset detection:
+Charset detection is important when dealing with content of unknown provenance,
+like content downloaded from the internet or text files uploaded by users. In
+such cases, users often have a declared encoding, typically from a content type.
+The name of the declared encoding can be provided as a hint to charset
+detection:
 
     try (Reader chars=Chardet.decode(bytes, declaredEncoding, StandardCharsets.UTF_8)) {
         // Process chars here
-    } catch(UnsupportedCharsetException e) {
-        // Process unsupported charset here
     }
 
 Byte arrays can be converted directly to Strings as well:
 
-    String chars;
-    try {
-        chars = Chardet.decode(bytes, declaredEncoding, StandardCharsets.UTF_8);
-    } catch(UnsupportedCharsetException e) {
-        // Could not decode chars because detected charset not supported by current JVM
-    }
+    String chars=Chardet.decode(bytes, declaredEncoding, StandardCharsets.UTF_8);
 
-Users can simply detect a character set, too:
+## Advanced Usage
 
-    // We can detect the charset by name. Never throws an exception.
-    Optional<String> maybeCharsetName = Chardet.detectCharsetName(bytes, declaredEncoding);
-    if(maybeCharsetName.isPresent()) {
-        // The charset was detected successfully.
-        String detectedCharsetName = maybeCharsetName.orElseThrow();
-        
-        // We can look up the charset by name at any point.
-        Charset detectedCharset;
-        try {
-            detectedCharset = Charset.forName(detectedCharsetName);
-            // The charset is supported by the current JVM.
-        } catch(UnsupportedCharsetException e) {
-            // The charset is not supported by the current JVM.
-        }
-    } else {
-        // The charset could not be detected. maybeCharsetName is empty.
-    }
-    
-    // We can detect the charset directly. Throws an UnsupportedCharsetException if
-    // the detected charset is not supported by the current JVM.
-    Optional<Charset> maybeCharset;
-    try {
-        maybeCharset = Chardet.detectCharset(bytes, declaredEncoding);
-        if(maybeCharset.isPresent()) {
-            // The charset was detected and is supported by current JVM.
-            Charset detectedCharset = maybeCharset.orElseThrow();
+The following are more sophisticated use cases and edge cases that most users
+will not need to worry about.
+
+### Working with BOMs Directly
+
+The easiest way to work with byte order marks directly is with the
+`BomAwareInputStream` class:
+
+    try (BomAwareInputStream bomed=BomAwareInputStream.detect(in)) {
+        if(bomed.bom().isPresent()) {
+            // A BOM was detected in this byte stream, and can be accessed using
+            // bomed.bom()
         } else {
-            // The charset could not be detected. maybeCharset is empty.
+            // No BOM was detected in this byte stream.
         }
-    } catch(UnsupportedCharsetException e) {
-        // The charset was detected, but is not supported by current JVM.
     }
+
+It is not typically required to work with BOMs directly, but it can be useful
+when creating a custom decode pipeline.
+
+### Accessing Character Encoding
+
+The easiest way to determine which character encoding is in use is with the
+`DecodedInputStreamReader` class:
+
+    try (DecodedInputStreamReader chars=Chardet.decode(bytes, StandardCharsets.UTF_8)) {
+        // The charset that was detected and is being used to decode the given byte
+        // stream can be accessed using chars.charset()
+        Charset charset = chars.charset();
+    }
+
+### Handling Unsupported Charsets
+
+The Java Standard only requires that distributions support the
+[standard charsets](https://docs.oracle.com/javase/8/docs/api/index.html?java/nio/charset/StandardCharsets.html)
+ISO-8859-1, US-ASCII, UTF-8, UTF-16BE, and UTF-16LE. This library detects those
+charsets and many more besides, so there is a possibility that the detected
+charset is not supported by the current JVM.
+
+Users are unlikely to hit this situation in the wild, since (a) Java generally
+supports almost all of the charsets this library detects, and (b) the
+unsupported charsets are scarce in the wild, and getting more scarce every year.
+
+Regardless, there are a couple ways to manage this situation.
+
+#### Catch UnsupportedCharsetException
+
+The library throws a `UnsupportedCharsetException` when the detected charset is not
+supported by the current JVM. Users are free to catch this exception and handle
+as desired.
+
+    try (Reader chars=Chardet.decode(bytes, StandardCharsets.UTF_8)) {
+        // Process chars here
+    } catch(UnsupportedCharsetException e) {
+        // The charset was detected, but is not supported by current JVM. There are a
+        // few ways this is typically handled:
+        // 
+        // - Propagate as an IOException, since the content cannot be decoded properly
+        // - Ignore the error and use a default charset
+    }
+
+#### Detect Charset Names
+
+Rather than working with charsets, work with charset names instead. This will
+never throw an exception.
+
+    Optional<String> maybeCharsetName = Chardet.detectCharsetName(bytes);
+    if(maybeCharsetName.isPresent()) {
+        // The charset was detected successfully, and the name can be accessed using
+        // maybeCharsetName.get()
+    } else {
+        // The charset could not be detected
+    }
+
+### Using Custom Charsets
+
+Users who wish to add new charsets to the JVM should follow the instructions
+on the
+[CharsetProvider](https://docs.oracle.com/javase/8/docs/api/java/nio/charset/spi/CharsetProvider.html)
+class. The library will automatically pick up any such new charsets.
     
-    
+## Configuration
+
+The following configuration variables are available to customize the working of
+the library.
+
+### System Property chardet4j.detect.bufsize
+
+One way the library detects character encodings is by analyzing the leading
+bytes of a binary file. The more data the library analyzes, the more accurate
+the estimates will be, but the longer it will take. By default, this value is
+8192 bytes, or 8KiB. Users can change this value by setting the
+`chardet4j.detect.bufsize` system property. For example, to set this value to 
+16KiB, use:
+
+    java -Dchardet.detect.bufsize=16384 ...
+
+Adjusting the buffer size can be useful when dealing with particularly large
+files where detection accuracy or performance might be a concern.
+
 ## Supported Character Encodings
 
 The chardet4j library and Java in general supports the following character
@@ -151,4 +228,4 @@ The support levels have the following meanings:
 ## Licensing
 
 The icu library is released under the ICU license. The chardet4j library is
-released under the Apache license.
+released under the Apache license. For more details, see the LICENSE file.

--- a/README.md
+++ b/README.md
@@ -88,10 +88,8 @@ encodings at the following levels:
 | windows-1254 |          |   ✔   |     |    ✔   |
 | windows-1255 |          |   ✔   |     |    ✔   |
 | windows-1256 |          |   ✔   |     |    ✔   |
-|:------------:|:--------:|:-----:|:---:|:------:|
-|     Name     | Standard | ICU4J | BOM | Laptop |
 
-Notes:
+Notes:  
 `*`: ICU4J detects US-ASCII as ISO-8859-1, a superset of US-ASCII
 
 The support levels have the following meanings:

--- a/pom.xml
+++ b/pom.xml
@@ -115,21 +115,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/sigpwned/chardet4j/ByteOrderMark.java
+++ b/src/main/java/com/sigpwned/chardet4j/ByteOrderMark.java
@@ -65,11 +65,6 @@ public enum ByteOrderMark {
   UTF_32LE(new byte[] {(byte) 0xFF, (byte) 0xFE, (byte) 0x00, (byte) 0x00}, null, "UTF-32LE"),
 
   /**
-   * The BOM for a UTF-7 stream
-   */
-  UTF_7(new byte[] {(byte) 0x2B, (byte) 0x2F, (byte) 0x76, (byte) 0x38}, null, "UTF-7"),
-
-  /**
    * The BOM for a UTF-1 stream
    */
   UTF_1(new byte[] {(byte) 0xF7, (byte) 0x64, (byte) 0x4C}, null, "UTF-1"),
@@ -80,19 +75,13 @@ public enum ByteOrderMark {
   UTF_EBCDIC(new byte[] {(byte) 0xDD, (byte) 0x73, (byte) 0x66, (byte) 0x73}, null, "UTF-EBCDIC"),
 
   /**
-   * The BOM for a SCSU stream
-   */
-  SCSU(new byte[] {(byte) 0x0E, (byte) 0xFE, (byte) 0xFF}, null, "SCSU"),
-
-  /**
-   * The BOM for a BOCU-1 stream
-   */
-  BOCU_1(new byte[] {(byte) 0xFB, (byte) 0xEE, (byte) 0x28}, null, "BOCU-1"),
-
-  /**
    * The BOM for a GB-18030 stream
    */
   GB_18030(new byte[] {(byte) 0x84, (byte) 0x31, (byte) 0x95, (byte) 0x33}, null, "GB-18030");
+  
+  // While BOMs for UTF-7, SCSU, and BOCU-1 exist, they are not deterministic and may not observe
+  // byte boundaries. Also, the JVM generally does not support these charsets out of the box. So,
+  // to keep things simple, these BOMs are not supported here.
 
   public static final int MAX_BYTE_LENGTH =
       Arrays.stream(values()).mapToInt(bom -> bom.getBytes().length).max().getAsInt();

--- a/src/main/java/com/sigpwned/chardet4j/ByteOrderMark.java
+++ b/src/main/java/com/sigpwned/chardet4j/ByteOrderMark.java
@@ -20,6 +20,8 @@
 package com.sigpwned.chardet4j;
 
 import static java.util.Objects.requireNonNull;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
@@ -29,6 +31,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import com.sigpwned.chardet4j.io.BomAwareInputStream;
 
 /**
  * A byte order mark (BOM) that hard-codes charset into an input stream. At this time, this
@@ -78,7 +81,7 @@ public enum ByteOrderMark {
    * The BOM for a GB-18030 stream
    */
   GB_18030(new byte[] {(byte) 0x84, (byte) 0x31, (byte) 0x95, (byte) 0x33}, null, "GB-18030");
-  
+
   // While BOMs for UTF-7, SCSU, and BOCU-1 exist, they are not deterministic and may not observe
   // byte boundaries. Also, the JVM generally does not support these charsets out of the box. So,
   // to keep things simple, these BOMs are not supported here.
@@ -96,6 +99,18 @@ public enum ByteOrderMark {
   }
 
   /**
+   * Detects the BOM in the given input stream, if any, and returns a {@link BomAwareInputStream}
+   * that wraps the stream.
+   * 
+   * @param in the input stream
+   * @return the {@link BomAwareInputStream}
+   * @throws IOException if an I/O error
+   */
+  public static BomAwareInputStream detect(InputStream in) throws IOException {
+    return BomAwareInputStream.detect(in);
+  }
+
+  /**
    * Returns the BOM for the given data, if it is supported. Searches the whole array.
    * 
    * @param data the data to check
@@ -106,7 +121,7 @@ public enum ByteOrderMark {
    * @see #detect(byte[], int)
    */
   public static Optional<ByteOrderMark> detect(byte[] data) {
-    if(data == null)
+    if (data == null)
       throw new NullPointerException();
     return detect(data, data.length);
   }
@@ -237,8 +252,12 @@ public enum ByteOrderMark {
   /**
    * @return the bytes
    */
-  public byte[] getBytes() {
+  /* default */ byte[] getBytes() {
     return bytes;
+  }
+
+  public int length() {
+    return bytes.length;
   }
 
   /**

--- a/src/main/java/com/sigpwned/chardet4j/ByteOrderMark.java
+++ b/src/main/java/com/sigpwned/chardet4j/ByteOrderMark.java
@@ -112,9 +112,13 @@ public enum ByteOrderMark {
    * @param data the data to check
    * @return the BOM, if found, otherwise empty
    * 
+   * @throws NullPointerException if {@code data} is {@code null}
+   * 
    * @see #detect(byte[], int)
    */
   public static Optional<ByteOrderMark> detect(byte[] data) {
+    if(data == null)
+      throw new NullPointerException();
     return detect(data, data.length);
   }
 
@@ -124,6 +128,9 @@ public enum ByteOrderMark {
    * @param data the data to check
    * @param len the length of the data to check
    * @return the BOM, if found, otherwise empty
+   * 
+   * @throws NullPointerException if {@code data} is {@code null}
+   * @throws IllegalArgumentException if {@code len < 0}
    * 
    * @see #detect(byte[], int, int)
    */
@@ -277,7 +284,8 @@ public enum ByteOrderMark {
       try {
         c = Charset.forName(charsetName);
       } catch (IllegalCharsetNameException e) {
-        // If the charset name is illegal, then set the cached charset to null.
+        // Odd. None of these charset names should be invalid. Just treat it like it's not supported
+        // and set the cached charset to null.
         c = null;
       } catch (UnsupportedCharsetException e) {
         // If the charset is not supported, then set the cached charset to null.

--- a/src/main/java/com/sigpwned/chardet4j/ByteOrderMark.java
+++ b/src/main/java/com/sigpwned/chardet4j/ByteOrderMark.java
@@ -131,6 +131,7 @@ public enum ByteOrderMark {
    * 
    * @throws NullPointerException if {@code data} is {@code null}
    * @throws IllegalArgumentException if {@code len < 0}
+   * @throws ArrayIndexOutOfBoundsException if {@code len > data.length}
    * 
    * @see #detect(byte[], int, int)
    */

--- a/src/main/java/com/sigpwned/chardet4j/Chardet.java
+++ b/src/main/java/com/sigpwned/chardet4j/Chardet.java
@@ -154,6 +154,7 @@ public final class Chardet {
    * 
    * @throws NullPointerException if data is null
    * @throws IllegalArgumentException if len < 0
+   * @throws ArrayIndexOutOfBoundsException if len > data.length
    * @throws UnsupportedOperationException If the charset can be detected, but is not supported.
    */
   public static Optional<Charset> detectCharset(byte[] data, int len, String declaredEncoding) {
@@ -301,6 +302,14 @@ public final class Chardet {
   /**
    * Returns a character-decoded version of the given byte stream. Any leading BOMs are discarded.
    * If no character set can be detected, then the given default is used.
+   * 
+   * @param input the input stream
+   * @param defaultCharset the default charset to use if no other can be detected
+   * 
+   * @throws NullPointerException if input is null
+   * @throws NullPointerException if defaultCharset is null
+   * @throws IOException if an I/O error occurs
+   * @throws UnsupportedCharsetException if the detected charset is not supported
    */
   public static DecodedInputStreamReader decode(InputStream input, Charset defaultCharset)
       throws IOException {
@@ -339,10 +348,8 @@ public final class Chardet {
         break;
     }
 
-    // TODO What exception should we throw here?
+    // Note that this cannot be null, since we check defaultCharset above.
     Charset charset = detectCharset(buf, buflen, declaredEncoding).orElse(defaultCharset);
-    if (charset == null)
-      throw new NullPointerException();
 
     int offset;
     Optional<ByteOrderMark> maybeBom = ByteOrderMark.detect(buf, buflen);
@@ -368,10 +375,13 @@ public final class Chardet {
    * @param defaultCharset the default charset to use if no other can be detected
    * @return the character-decoded string
    * 
+   * @throws NullPointerException if data is null
    * @throws UnsupportedCharsetException if the detected charset is not supported
+   * @throws UncheckedIOException if an I/O error occurs, which should not happen because all I/O
+   *         operations are performed in-memory
    */
   public static String decode(byte[] data, Charset defaultCharset) {
-    return decode(data, data.length, null, defaultCharset);
+    return decode(data, null, defaultCharset);
   }
 
   /**
@@ -385,9 +395,14 @@ public final class Chardet {
    * @param defaultCharset the default charset to use if no other can be detected
    * @return the character-decoded string
    * 
+   * @throws NullPointerException if data is null
    * @throws UnsupportedCharsetException if the detected charset is not supported
+   * @throws UncheckedIOException if an I/O error occurs, which should not happen because all I/O
+   *         operations are performed in-memory
    */
   public static String decode(byte[] data, String declaredEncoding, Charset defaultCharset) {
+    if (data == null)
+      throw new NullPointerException();
     return decode(data, data.length, declaredEncoding, defaultCharset);
   }
 
@@ -403,7 +418,12 @@ public final class Chardet {
    * @param defaultCharset the default charset to use if no other can be detected
    * @return the character-decoded string
    * 
+   * @throws NullPointerException if data is null
+   * @throws IllegalArgumentException if len < 0
+   * @throws ArrayIndexOutOfBoundsException if len > data.length
    * @throws UnsupportedCharsetException if the detected charset is detected, but not supported
+   * @throws UncheckedIOException if an I/O error occurs, which should not happen because all I/O
+   *         operations are performed in-memory
    */
   public static String decode(byte[] data, int len, String declaredEncoding,
       Charset defaultCharset) {

--- a/src/main/java/com/sigpwned/chardet4j/Chardet.java
+++ b/src/main/java/com/sigpwned/chardet4j/Chardet.java
@@ -23,30 +23,26 @@ import static java.util.stream.Collectors.toList;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.SequenceInputStream;
+import java.io.StringWriter;
 import java.io.UncheckedIOException;
+import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import com.sigpwned.chardet4j.com.ibm.icu.text.CharsetDetector;
-import com.sigpwned.chardet4j.com.ibm.icu.text.CharsetMatch;
+import com.sigpwned.chardet4j.io.DecodedInputStreamReader;
 
 /**
  * Simple interface to charset detection.
  */
 public final class Chardet {
   private Chardet() {}
-
-  /**
-   * Detect the charset of the given byte data. Input includes the entire array.
-   */
-  public static Optional<Charset> detectCharset(byte[] data) {
-    return detectCharset(data, null);
-  }
 
   private static final int MIN_CONFIDENCE = 0;
   private static final int MAX_CONFIDENCE = 100;
@@ -117,63 +113,182 @@ public final class Chardet {
     }
   }
 
+  // detectCharset /////////////////////////////////////////////////////////////////////////////////
+
   /**
-   * Detect the charset of the given byte data with the given encoding as a hint. Input includes the
-   * entire array.
+   * Detect the charset of the given byte data. Input includes the entire array. If the character
+   * encoding is detected, but not supported, then an {@link UnsupportedCharsetException} is thrown.
+   * 
+   * @throws NullPointerException if data is null
+   * @throws UnsupportedOperationException If the charset can be detected, but is not supported.
    */
-  public static Optional<Charset> detectCharset(byte[] data, String declaredEncoding) {
-    Optional<ByteOrderMark> maybeBom = ByteOrderMark.detect(data);
-    if (maybeBom.isPresent()) {
-      return maybeBom.map(ByteOrderMark::getCharset);
-    }
-
-    CharsetDetector chardet = new CharsetDetector();
-
-    chardet.setText(data);
-
-    List<ChardetMatch> matches = Arrays.stream(chardet.detectAll()).map(mi -> {
-      String name = mi.getName();
-      int confidence = name.equalsIgnoreCase(declaredEncoding)
-          ? Math.min(mi.getConfidence() + DECLARED_ENCODING_BUMP, MAX_CONFIDENCE)
-          : mi.getConfidence();
-      return ChardetMatch.of(name, confidence);
-    }).sorted(Comparator.reverseOrder()).collect(toList());
-
-    return matches.isEmpty() ? Optional.empty()
-        : Optional.of(matches.get(0).getName()).map(Charset::forName);
+  public static Optional<Charset> detectCharset(byte[] data) {
+    return detectCharset(data, null);
   }
 
   /**
-   * Detect the charset of the given byte data in the first datalen bytes with the given encoding as
-   * a hint.
+   * Detect the charset of the given byte data with the given encoding as a hint. Input includes the
+   * entire array. If the character encoding is detected, but not supported, then an
+   * {@link UnsupportedCharsetException} is thrown.
+   * 
+   * @param data the byte data
+   * @param declaredEncoding the declared encoding, treated as a hint
+   * @return the charset, if one can be detected
+   * 
+   * @throws NullPointerException if data is null
+   * @throws UnsupportedOperationException If the charset can be detected, but is not supported.
    */
-  public static Optional<Charset> detectCharset(byte[] data, int datalen, String declaredEncoding) {
-    Optional<ByteOrderMark> maybeBom = ByteOrderMark.detect(data, datalen);
+  public static Optional<Charset> detectCharset(byte[] data, String declaredEncoding) {
+    return detectCharset(data, data.length, declaredEncoding);
+  }
+
+  /**
+   * Detect the charset encoding of the given byte data in the first len bytes of the given array.
+   * If the character encoding is detected, but not supported, then an
+   * {@link UnsupportedCharsetException} is thrown.
+   * 
+   * @param data the byte data
+   * @param len the number of bytes to consider, starting from 0
+   * @param declaredEncoding the optional declared encoding, which is treated as a hint
+   * @return the charset encoding, if one can be detected
+   * 
+   * @throws NullPointerException if data is null
+   * @throws IllegalArgumentException if len < 0
+   * @throws UnsupportedOperationException If the charset can be detected, but is not supported.
+   */
+  public static Optional<Charset> detectCharset(byte[] data, int len, String declaredEncoding) {
+    return detectCharset(data, 0, len, declaredEncoding);
+  }
+
+  /**
+   * Detect the charset encoding of the given byte data in the given range of the given array. If
+   * the character encoding is detected, but not supported, then an
+   * {@link UnsupportedCharsetException} is thrown.
+   * 
+   * @param data the byte data
+   * @param off the offset into the byte data
+   * @param len the number of bytes to consider
+   * @param declaredEncoding the optional declared encoding, which is treated as a hint
+   * @return the charset encoding, if one can be detected
+   * 
+   * @throws NullPointerException if data is null
+   * @throws IllegalArgumentException if len < 0
+   * @throws ArrayIndexOutOfBoundsException if off < 0 or off + len > data.length
+   * @throws UnsupportedOperationException If the charset can be detected, but is not supported. To
+   *         get the charset name whether it is supported or not, use
+   *         {@link #detectCharsetName(byte[], int, String)}.
+   */
+  public static Optional<Charset> detectCharset(byte[] data, int off, int len,
+      String declaredEncoding) {
+    return detectCharsetName(data, off, len, declaredEncoding).map(Charset::forName);
+  }
+
+  // detectCharsetName /////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Detect the charset of the given byte data. Input includes the entire array.
+   * 
+   * @throws NullPointerException if data is null
+   */
+  public static Optional<String> detectCharsetName(byte[] data) {
+    return detectCharsetName(data, null);
+  }
+
+  /**
+   * Detect the charset of the given byte data. Input includes the entire array.
+   * 
+   * @param data the byte data
+   * @param declaredEncoding the declared encoding, treated as a hint
+   * @return the charset name, if one is detected
+   * 
+   * @throws NullPointerException if data is null
+   */
+  public static Optional<String> detectCharsetName(byte[] data, String declaredEncoding) {
+    return detectCharsetName(data, data.length, declaredEncoding);
+  }
+
+  /**
+   * Detect the name of the charset encoding of the given byte data in the first len bytes of the
+   * given array.
+   * 
+   * @param data the byte data
+   * @param len the number of bytes to consider, starting from 0
+   * @param declaredEncoding the optional declared encoding, which is treated as a hint
+   * @return the charset encoding, if one can be detected
+   * 
+   * @throws NullPointerException if data is null
+   * @throws IllegalArgumentException if len < 0
+   * @throws ArrayIndexOutOfBoundsException if len > data.length
+   */
+  public static Optional<String> detectCharsetName(byte[] data, int len, String declaredEncoding) {
+    return detectCharsetName(data, 0, len, declaredEncoding);
+  }
+
+  /**
+   * Detect the name of the charset encoding of the given range of the given array.
+   * 
+   * @param data the byte data
+   * @param len the number of bytes to consider, starting from 0
+   * @param declaredEncoding the optional declared encoding, which is treated as a hint
+   * @return the charset encoding, if one can be detected
+   * 
+   * @throws NullPointerException if data is null
+   * @throws IllegalArgumentException if len < 0
+   * @throws ArrayIndexOutOfBoundsException if off < 0 or off + len > data.length
+   */
+  public static Optional<String> detectCharsetName(byte[] data, int off, int len,
+      String declaredEncoding) {
+    if (data == null)
+      throw new NullPointerException();
+    if (len < 0)
+      throw new IllegalArgumentException("len < 0");
+    if (off < 0)
+      throw new ArrayIndexOutOfBoundsException(off);
+    if (off + len > data.length)
+      throw new ArrayIndexOutOfBoundsException(off + len);
+
+    Optional<ByteOrderMark> maybeBom = ByteOrderMark.detect(data, off, len);
     if (maybeBom.isPresent()) {
-      return maybeBom.map(ByteOrderMark::getCharset);
+      return maybeBom.map(ByteOrderMark::getCharsetName);
     }
 
     CharsetDetector chardet = new CharsetDetector();
 
-    if (datalen == data.length) {
+    if (off == 0 && len == data.length) {
       // Let's avoid a byte copy if we can
       chardet.setText(data);
     } else {
       try {
-        chardet.setText(new ByteArrayInputStream(data, 0, datalen));
+        chardet.setText(new ByteArrayInputStream(data, off, len));
       } catch (IOException e) {
         // This should never happen in a ByteArrayInputStream
         throw new UncheckedIOException("unexpected exception when reading from byte array", e);
       }
     }
 
-    if (declaredEncoding != null)
-      chardet.setDeclaredEncoding(declaredEncoding);
+    // Ideally, we'd just use this methods from the CharsetDetector class, but the declared encoding
+    // is ignored. So we have to do it ourselves.
+    // if (declaredEncoding != null)
+    // chardet.setDeclaredEncoding(declaredEncoding);
 
-    CharsetMatch match = chardet.detect();
+    List<ChardetMatch> matches = Arrays.stream(chardet.detectAll()).map(mi -> {
+      String name = mi.getName();
 
-    return Optional.ofNullable(match).map(m -> Charset.forName(m.getName()));
+      int confidence = mi.getConfidence();
+      if (declaredEncoding != null && name.equalsIgnoreCase(declaredEncoding))
+        confidence = Math.min(confidence + DECLARED_ENCODING_BUMP, MAX_CONFIDENCE);
+
+      return ChardetMatch.of(name, confidence);
+    }).sorted(Comparator.reverseOrder()).collect(toList());
+
+    if (matches.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(matches.get(0).getName());
   }
+
+  // decode ////////////////////////////////////////////////////////////////////////////////////////
 
   /**
    * The default is chosen based on a reading of the CharsetDetector source code, which sets buffer
@@ -187,7 +302,7 @@ public final class Chardet {
    * Returns a character-decoded version of the given byte stream. Any leading BOMs are discarded.
    * If no character set can be detected, then the given default is used.
    */
-  public static InputStreamReader decode(InputStream input, Charset defaultCharset)
+  public static DecodedInputStreamReader decode(InputStream input, Charset defaultCharset)
       throws IOException {
     return decode(input, null, defaultCharset);
   }
@@ -195,10 +310,26 @@ public final class Chardet {
   /**
    * Returns a character-decoded version of the given byte stream. The declared encoding is treated
    * as a hint. Any leading BOMs are discarded. If no character set can be detected, then the given
-   * default is used.
+   * default is used. If the character set is detected, but not supported, then an
+   * {@link UnsupportedCharsetException} is thrown.
+   * 
+   * @param input the input stream
+   * @param declaredEncoding the declared encoding, treated as a hint
+   * @param defaultCharset the default charset to use if no other can be detected
+   * @return the character-decoded stream
+   * 
+   * @throws NullPointerException if input is null
+   * @throws NullPointerException if defaultCharset is null
+   * @throws IOException if an I/O error occurs
+   * @throws UnsupportedCharsetException if the detected charset is not supported
    */
-  public static InputStreamReader decode(InputStream input, String declaredEncoding,
+  public static DecodedInputStreamReader decode(InputStream input, String declaredEncoding,
       Charset defaultCharset) throws IOException {
+    if (input == null)
+      throw new NullPointerException();
+    if (defaultCharset == null)
+      throw new NullPointerException();
+
     int buflen = 0;
     byte[] buf = new byte[DECODE_DETECT_BUFSIZE];
     for (int nread = input.read(buf, buflen, buf.length - buflen); nread != -1; nread =
@@ -208,7 +339,10 @@ public final class Chardet {
         break;
     }
 
+    // TODO What exception should we throw here?
     Charset charset = detectCharset(buf, buflen, declaredEncoding).orElse(defaultCharset);
+    if (charset == null)
+      throw new NullPointerException();
 
     int offset;
     Optional<ByteOrderMark> maybeBom = ByteOrderMark.detect(buf, buflen);
@@ -218,7 +352,7 @@ public final class Chardet {
       offset = 0;
     }
 
-    return new InputStreamReader(
+    return new DecodedInputStreamReader(
         new SequenceInputStream(new ByteArrayInputStream(buf, offset, buflen - offset), input),
         charset);
   }
@@ -226,7 +360,32 @@ public final class Chardet {
   /**
    * Returns a character-decoded String version of the given bytes. The declared encoding is treated
    * as a hint. Any leading BOMs are discarded. If no character set can be detected, then the given
-   * default is used.
+   * default is used. If the character set is detected, but not supported, then an
+   * {@link UnsupportedCharsetException} is thrown.
+   * 
+   * @param data the byte data
+   * @param declaredEncoding the declared encoding, treated as a hint
+   * @param defaultCharset the default charset to use if no other can be detected
+   * @return the character-decoded string
+   * 
+   * @throws UnsupportedCharsetException if the detected charset is not supported
+   */
+  public static String decode(byte[] data, Charset defaultCharset) {
+    return decode(data, data.length, null, defaultCharset);
+  }
+
+  /**
+   * Returns a character-decoded String version of the given bytes. The declared encoding is treated
+   * as a hint. Any leading BOMs are discarded. If no character set can be detected, then the given
+   * default is used. If the character set is detected, but not supported, then an
+   * {@link UnsupportedCharsetException} is thrown.
+   * 
+   * @param data the byte data
+   * @param declaredEncoding the declared encoding, treated as a hint
+   * @param defaultCharset the default charset to use if no other can be detected
+   * @return the character-decoded string
+   * 
+   * @throws UnsupportedCharsetException if the detected charset is not supported
    */
   public static String decode(byte[] data, String declaredEncoding, Charset defaultCharset) {
     return decode(data, data.length, declaredEncoding, defaultCharset);
@@ -235,22 +394,66 @@ public final class Chardet {
   /**
    * Returns a character-decoded String version of the given bytes. The declared encoding is treated
    * as a hint. Any leading BOMs are discarded. If no character set can be detected, then the given
-   * default is used.
+   * default is used. If the character set is detected, but not supported, then an
+   * {@link UnsupportedCharsetException} is thrown.
+   * 
+   * @param data the byte data
+   * @param len the number of bytes to consider, starting from 0
+   * @param declaredEncoding the declared encoding, treated as a hint
+   * @param defaultCharset the default charset to use if no other can be detected
+   * @return the character-decoded string
+   * 
+   * @throws UnsupportedCharsetException if the detected charset is detected, but not supported
    */
-  public static String decode(byte[] data, int datalen, String declaredEncoding,
+  public static String decode(byte[] data, int len, String declaredEncoding,
       Charset defaultCharset) {
-    // We work directly with the byte array here as opposed to wrapping in an InputStream to avoid
-    // extra copies. Performance matters.
-    Charset charset = detectCharset(data, datalen, declaredEncoding).orElse(defaultCharset);
+    return decode(data, 0, len, declaredEncoding, defaultCharset);
+  }
 
-    int offset;
-    Optional<ByteOrderMark> maybeBom = ByteOrderMark.detect(data, datalen);
-    if (maybeBom.isPresent()) {
-      offset = maybeBom.map(bom -> bom.getBytes().length).get().intValue();
-    } else {
-      offset = 0;
+  /**
+   * Returns a character-decoded String version of the given bytes. The declared encoding is treated
+   * as a hint. Any leading BOMs are discarded. If no character set can be detected, then the given
+   * default is used. If the character set is detected, but not supported, then an
+   * {@link UnsupportedCharsetException} is thrown.
+   * 
+   * @param data the byte data
+   * @param off the offset into the byte data
+   * @param len the number of bytes to consider, starting at off
+   * @param declaredEncoding the declared encoding, treated as a hint
+   * @param defaultCharset the default charset to use if no other can be detected
+   * @return the character-decoded string
+   * 
+   * @throws NullPointerException if data is null
+   * @throws NullPointerException if defaultCharset is null
+   * @throws IllegalArgumentException if len < 0
+   * @throws ArrayIndexOutOfBoundsException if off < 0 or off + len > data.length
+   * @throws UnsupportedCharsetException if the detected charset is detected, but not supported
+   * @throws UncheckedIOException if an I/O error occurs, which should not happen because all I/O
+   *         operations are performed in-memory
+   */
+  public static String decode(byte[] data, int off, int len, String declaredEncoding,
+      Charset defaultCharset) {
+    if (data == null)
+      throw new NullPointerException();
+    if (defaultCharset == null)
+      throw new NullPointerException();
+    if (len < 0)
+      throw new IllegalArgumentException("len < 0");
+    if (off < 0)
+      throw new ArrayIndexOutOfBoundsException(off);
+    if (off + len > data.length)
+      throw new ArrayIndexOutOfBoundsException(off + len);
+
+    try (InputStream in = new ByteArrayInputStream(data, off, len);
+        Reader r = decode(in, declaredEncoding, defaultCharset);
+        Writer w = new StringWriter()) {
+      char[] chbuf = new char[8192];
+      for (int nread = r.read(chbuf); nread != -1; nread = r.read(chbuf)) {
+        w.write(chbuf, 0, nread);
+      }
+      return w.toString();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
-
-    return new String(data, offset, datalen - offset, charset);
   }
 }

--- a/src/main/java/com/sigpwned/chardet4j/io/BomAwareInputStream.java
+++ b/src/main/java/com/sigpwned/chardet4j/io/BomAwareInputStream.java
@@ -1,0 +1,84 @@
+/*-
+ * =================================LICENSE_START==================================
+ * chardet4j
+ * ====================================SECTION=====================================
+ * Copyright (C) 2022 - 2024 Andy Boothe
+ * ====================================SECTION=====================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==================================LICENSE_END===================================
+ */
+package com.sigpwned.chardet4j.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.util.Optional;
+import com.sigpwned.chardet4j.ByteOrderMark;
+import com.sigpwned.chardet4j.util.ByteStreams;
+
+/**
+ * A wrapper {@link InputStream} that remembers the {@link ByteOrderMark} that was detected at the
+ * beginning of the stream.
+ */
+public final class BomAwareInputStream extends FilterInputStream {
+  /**
+   * Detect the {@link ByteOrderMark} at the beginning of the stream, if any, and return a
+   * {@link BomAwareInputStream} that wraps the stream.
+   *
+   * @param in the input stream
+   * @return the {@link BomAwareInputStream}
+   * @throws IOException if an I/O error occurs
+   */
+  public static BomAwareInputStream detect(InputStream in) throws IOException {
+    final byte[] buf = ByteStreams.readNBytes(in, ByteOrderMark.MAX_BYTE_LENGTH);
+
+    ByteOrderMark bom = ByteOrderMark.detect(buf).orElse(null);
+
+    // If there is no BOM, then return all the bytes read so far, followed by the rest of the stream
+    if (bom == null)
+      return new BomAwareInputStream(new SequenceInputStream(new ByteArrayInputStream(buf), in),
+          null);
+
+    final int bomlen = bom.length();
+
+    // If there is a BOM and it is the same length as the bytes read so far, then return the rest of
+    // the stream
+    if (bomlen == buf.length)
+      return new BomAwareInputStream(in, bom);
+
+    // If there is a BOM and it is shorter than the bytes read so far, then return the BOM followed
+    // by the rest of the bytes read so far, followed by the rest of the stream
+    return new BomAwareInputStream(
+        new SequenceInputStream(new ByteArrayInputStream(buf, bomlen, buf.length - bomlen), in),
+        bom);
+  }
+
+  private final ByteOrderMark bom;
+
+  private BomAwareInputStream(InputStream delegate, ByteOrderMark bom) {
+    super(delegate);
+    this.bom = bom;
+  }
+
+  /**
+   * The {@link ByteOrderMark} that was detected at the beginning of the stream, if any, or else
+   * empty.
+   *
+   * @return the {@link ByteOrderMark}
+   */
+  public Optional<ByteOrderMark> bom() {
+    return Optional.ofNullable(bom);
+  }
+}

--- a/src/main/java/com/sigpwned/chardet4j/io/DecodedInputStreamReader.java
+++ b/src/main/java/com/sigpwned/chardet4j/io/DecodedInputStreamReader.java
@@ -1,0 +1,47 @@
+/*-
+ * =================================LICENSE_START==================================
+ * chardet4j
+ * ====================================SECTION=====================================
+ * Copyright (C) 2022 - 2024 Andy Boothe
+ * ====================================SECTION=====================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==================================LICENSE_END===================================
+ */
+package com.sigpwned.chardet4j.io;
+
+import static java.util.Objects.requireNonNull;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+
+/**
+ * A simple wrapper around an InputStreamReader that remembers the charset that was used to decode
+ * the input stream.
+ */
+public class DecodedInputStreamReader extends InputStreamReader {
+  private final Charset charset;
+
+  public DecodedInputStreamReader(InputStream in, Charset charset) {
+    super(in, charset);
+    this.charset = requireNonNull(charset);
+  }
+
+  /**
+   * The charset that was used to decode the input stream.
+   *
+   * @return the charset
+   */
+  public Charset charset() {
+    return charset;
+  }
+}

--- a/src/main/java/com/sigpwned/chardet4j/io/DecodedInputStreamReader.java
+++ b/src/main/java/com/sigpwned/chardet4j/io/DecodedInputStreamReader.java
@@ -28,7 +28,7 @@ import java.nio.charset.Charset;
  * A simple wrapper around an InputStreamReader that remembers the charset that was used to decode
  * the input stream.
  */
-public class DecodedInputStreamReader extends InputStreamReader {
+public final class DecodedInputStreamReader extends InputStreamReader {
   private final Charset charset;
 
   public DecodedInputStreamReader(InputStream in, Charset charset) {

--- a/src/main/java/com/sigpwned/chardet4j/util/ByteStreams.java
+++ b/src/main/java/com/sigpwned/chardet4j/util/ByteStreams.java
@@ -1,0 +1,67 @@
+/*-
+ * =================================LICENSE_START==================================
+ * chardet4j
+ * ====================================SECTION=====================================
+ * Copyright (C) 2022 - 2024 Andy Boothe
+ * ====================================SECTION=====================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==================================LICENSE_END===================================
+ */
+package com.sigpwned.chardet4j.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * Utility methods for working with {@link InputStream byte streams}.
+ */
+public final class ByteStreams {
+  private ByteStreams() {}
+
+  /**
+   * Read as many bytes as possible from the the given {@link InputStream}, up to count, and return
+   * them as a byte array. If the stream ends before count bytes can be read, then the returned
+   * array will be shorter than count. Equivalent to the Java 9+ {@code InputStream} method of the
+   * same name.
+   * 
+   * @param in the input stream
+   * @param count the maximum number of bytes to read
+   * @return the bytes read
+   * @throws NullPointerException if in is null
+   * @throws IllegalArgumentException if count is negative
+   * @throws IOException if an I/O error occurs
+   */
+  public static byte[] readNBytes(InputStream in, int count) throws IOException {
+    if (in == null)
+      throw new NullPointerException();
+    if (count < 0)
+      throw new IllegalArgumentException("count must not be negative");
+
+    final byte[] buf = new byte[count];
+    if (count == 0)
+      return buf;
+
+    int len = 0;
+    for (int nread = in.read(buf); nread != -1; nread = in.read(buf, len, buf.length - len)) {
+      len = len + nread;
+      if (len == buf.length)
+        break;
+    }
+
+    if (len == buf.length)
+      return buf;
+
+    return Arrays.copyOf(buf, len);
+  }
+}

--- a/src/main/java/com/sigpwned/chardet4j/util/CharStreams.java
+++ b/src/main/java/com/sigpwned/chardet4j/util/CharStreams.java
@@ -1,0 +1,56 @@
+/*-
+ * =================================LICENSE_START==================================
+ * chardet4j
+ * ====================================SECTION=====================================
+ * Copyright (C) 2022 - 2024 Andy Boothe
+ * ====================================SECTION=====================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==================================LICENSE_END===================================
+ */
+package com.sigpwned.chardet4j.util;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+
+public final class CharStreams {
+  private CharStreams() {}
+
+  /**
+   * Copy all characters from the given {@link Reader} to the given {@link Writer} and return the
+   * total number of characters copied. Equivalent to the Java 9+ {@code Reader} method of the same
+   * name.
+   *
+   * @param in the input reader
+   * @param out the output writer
+   * @return the total number of characters copied
+   * @throws NullPointerException if in or out is null
+   * @throws IOException if an I/O error occurs
+   */
+  public static long transferTo(Reader in, Writer out) throws IOException {
+    if (in == null)
+      throw new NullPointerException();
+    if (out == null)
+      throw new NullPointerException();
+
+    long total = 0;
+
+    final char[] buf = new char[8192];
+    for (int nread = in.read(buf); nread != -1; nread = in.read(buf)) {
+      out.write(buf, 0, nread);
+      total = total + nread;
+    }
+
+    return total;
+  }
+}


### PR DESCRIPTION
Allows the library to *identify* character encodings without *supporting* them. Fixes #43.